### PR TITLE
support leading/trailing whitespace

### DIFF
--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -10,7 +10,7 @@ attr_accessor :guess, :card
   end
 
   def correct?
-    @guess.downcase == card.answer.downcase
+    @guess.downcase.strip == card.answer.downcase.strip
   end
 
   def feedback

--- a/test/turn_test.rb
+++ b/test/turn_test.rb
@@ -33,4 +33,11 @@ class TurnTest < Minitest::Test
     assert_equal "Incorrect.", turn.feedback
   end
 
+  def test_white_space_wrong_case_correct_responses
+    card = Card.new("What is the capital of Alaska?", "Juneau", :Geography)
+    turn = Turn.new("  Juneau ", card)
+
+    assert_equal true, turn.correct?
+  end
+
 end


### PR DESCRIPTION
Adds ability for user to enter correct answers with leading or trailing whitespace. Adds new test to cover whitespace case.